### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/zhongmingyuan-mcp-my-mac-badge.png)](https://mseep.ai/app/zhongmingyuan-mcp-my-mac)
 
+<a href="https://glama.ai/mcp/servers/@zhongmingyuan/mcp-my-mac">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zhongmingyuan/mcp-my-mac/badge" alt="mcp-my-mac MCP server" />
+</a>
+
 # MCP My Mac
 
 A lightweight server that exposes Mac system information via a simple API, allowing AI assistants like Claude to access real-time system information about your Mac. This tool is primarily designed for Mac users who want to experiment with AI and Deep Learning on their machines.


### PR DESCRIPTION
This PR adds a badge for the [mcp-my-mac](https://glama.ai/mcp/servers/@zhongmingyuan/mcp-my-mac) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@zhongmingyuan/mcp-my-mac">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zhongmingyuan/mcp-my-mac/badge" alt="mcp-my-mac MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a clickable badge in the README linking to the MCP server page on glama.ai for the "mcp-my-mac" project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->